### PR TITLE
Fix link to other tor posts

### DIFF
--- a/blog/2016/04/05/what-happens-when-tor-exit-nodes-break-bad/index.html
+++ b/blog/2016/04/05/what-happens-when-tor-exit-nodes-break-bad/index.html
@@ -154,7 +154,7 @@
 
 <h3 id="introduction:f95a411bd10674adcf2a6a8ceddf9328">Introduction</h3>
 
-<p>When <a href="/blog/categories/tor/">looking at how Tor works</a>, we&rsquo;ve looked at the various types of nodes that make up the Tor network. However, you&rsquo;ll notice that we haven&rsquo;t dealt too much with <em>exit nodes</em>. Exit nodes are the final link in a Tor &ldquo;circuit&rdquo;, or path from the client to the server. Since exit nodes send data to the final destination, they can see the data as if it had just left the device.</p>
+<p>When <a href="/blog/tags/tor/">looking at how Tor works</a>, we&rsquo;ve looked at the various types of nodes that make up the Tor network. However, you&rsquo;ll notice that we haven&rsquo;t dealt too much with <em>exit nodes</em>. Exit nodes are the final link in a Tor &ldquo;circuit&rdquo;, or path from the client to the server. Since exit nodes send data to the final destination, they can see the data as if it had just left the device.</p>
 
 <p>This visibility puts quite a bit of trust in exit nodes and, for the most part, they tend to act responsibly. However, this isn&rsquo;t always the case. This post will take a look at what happens when a Tor <a href="https://i.imgur.com/L8L7k1Z.jpg">exit node operator</a> decides to &ldquo;break bad&rdquo; and wreak havoc on Tor users<a href="#end-1"><sup>1</sup></a>.</p>
 


### PR DESCRIPTION
Just noticed that in this blog post you link to `blog/categories/tor/` but the correct URL appears to be `blog/tags/tor/`. Thanks for your posts! Hopefully this will help others find them more easily.
